### PR TITLE
Support RegExp expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,27 @@ The module exposes a single function, `.spawn`.
 Top-level entry point for `nexpect` that liberally parses the arguments
 and then returns a new chain with the specified `command`, `params`, and `options`.
 
-### function expect (str)
+### function expect (expectation)
 
-* str {string} Output to assert on the target stream
+* expectation {string|RegExp} Output to assert on the target stream
 
-Expect that the next line of output contains `str` as a sub-string, fails if it
-does not.
+Expect that the next line of output matches the expectation.
+Throw an error if it does not.
 
-### function wait (str)
+The expectation can be a string (the line should contain the expected value as
+a substring) or a RegExp (the line should match the expression).
 
-* str {string} Output to assert on the target stream
+### function wait (expectation)
 
-Wait for a line of output that contains `str` as a sub-string, discarding lines
-that do not match, fails if `str` is not found.
+* expectation {string|RegExp} Output to assert on the target stream
+
+Wait for a line of output that matches the expectation, discarding lines
+that do not match.
+
+Throw an error if no such line was found.
+
+The expectation can be a string (the line should contain the expected value as
+a substring) or a RegExp (the line should match the expression).
 
 ### function sendline (line)
 

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -6,12 +6,13 @@
  */
 
 var spawn = require('child_process').spawn;
+var util = require('util');
 
 function chain (context) {
   return {
-    expect: function (str) {
+    expect: function (expectation) {
       var _expect = function _expect (data) {
-        return data.indexOf(str) > -1;
+        return testExpectation(data, expectation);
       };
 
       _expect.shift = true;
@@ -19,9 +20,9 @@ function chain (context) {
 
       return chain(context);
     },
-    wait: function (str) {
+    wait: function (expectation) {
       var _wait = function _wait (data) {
-        return data.indexOf(str) > -1;
+        return testExpectation(data, expectation);
       };
 
       _wait.shift = false;
@@ -271,6 +272,14 @@ function chain (context) {
       return context.process;
     }
   };
+}
+
+function testExpectation(data, expectation) {
+  if (util.isRegExp(expectation)) {
+    return expectation.test(data);
+  } else {
+    return data.indexOf(expectation) > -1;
+  }
 }
 
 function nspawn (command, params, options) {

--- a/test/nexpect-test.js
+++ b/test/nexpect-test.js
@@ -61,6 +61,12 @@ vows.describe('nexpect').addBatch({
               .expect("testing")
               .sendline("process.exit()")
       ),
+      "and using the expect() method": {
+        "when RegExp expectation is met": assertSpawn(
+          nexpect.spawn("echo", ["hello"])
+                 .expect(/^hello$/)
+        ),
+      },
       "and using the wait() method": {
         "when assertions are met": assertSpawn(
           nexpect.spawn(path.join(__dirname, 'fixtures', 'prompt-and-respond'))


### PR DESCRIPTION
Modify _expect() and _wait() to support both sub-string and RegExp
specifications of what output is expected.

@sam-github @indexzero
Could one of you review the patch please?
