### PR TITLE
Improve the error reported by a failed expectation

### DIFF
--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -7,6 +7,7 @@
 
 var spawn = require('child_process').spawn;
 var util = require('util');
+var AssertionError = require('assert').AssertionError;
 
 function chain (context) {
   return {
@@ -16,6 +17,7 @@ function chain (context) {
       };
 
       _expect.shift = true;
+      _expect.expectation = expectation;
       context.queue.push(_expect);
 
       return chain(context);
@@ -26,6 +28,7 @@ function chain (context) {
       };
 
       _wait.shift = false;
+      _wait.expectation = expectation;
       context.queue.push(_wait);
       return chain(context);
     },
@@ -129,7 +132,7 @@ function chain (context) {
           //
           return currentFn(data) === true ?
             evalContext(data, '_expect') :
-            onError(new Error(data + ' was not expected..'), true);
+            onError(createExpectationError(currentFn.expectation, data), true);
         }
         else if (currentFn.name === '_wait') {
           //
@@ -207,7 +210,7 @@ function chain (context) {
         }
         else if (currentFn.name === '_wait' || currentFn.name === '_expect') {
           if (currentFn(lastLine) !== true) {
-            onError(new Error(lastLine + ' was not expected..'));
+            onError(createExpectationError(currentFn.expectation, lastLine));
             return false;
           }
         }
@@ -280,6 +283,21 @@ function testExpectation(data, expectation) {
   } else {
     return data.indexOf(expectation) > -1;
   }
+}
+
+function createExpectationError(expected, actual) {
+  var expectation;
+  if (util.isRegExp(expected))
+    expectation = 'to match ' + expected;
+  else
+    expectation = 'to contain ' + JSON.stringify(expected);
+
+  var err = new AssertionError({
+    message: util.format('expected %j %s', actual, expectation),
+    actual: actual,
+    expected: expected
+  });
+  return err;
 }
 
 function nspawn (command, params, options) {


### PR DESCRIPTION
Modify the error reported when a line does not match the expectation
provided by `expect` or `wait`:
- use assert.AssertionError instead of plain Error
- fill actual and expected properties
- include the expectation in the error message
