### PR TITLE
Improve message on nonempty queue + fix child hanging on stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ a substring) or a RegExp (the line should match the expression).
 Adds a write line to `context.process.stdin` to the `context.queue`
 for the current chain.
 
+### function sendEof ()
+
+Close child's stdin stream, let the child know there are no more data coming.
+
+This is useful for testing apps that are using inquirer,
+as `inquirer.prompt()` calls `stdin.resume()` at some point,
+which causes the app to block on input when the input stream is a pipe.
+
 ### function run (callback)
 
 * callback {function} Called when child process closes, with arguments

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -48,6 +48,14 @@ function chain (context) {
       context.queue.push(_sendline);
       return chain(context);
     },
+    sendEof: function() {
+      var _sendEof = function _sendEof () {
+        context.process.stdin.destroy();
+      };
+      _sendEof.shift = true;
+      context.queue.push(_sendEof);
+      return chain(context);
+    },
     run: function (callback) {
       var errState = null,
           responded = false,
@@ -90,7 +98,7 @@ function chain (context) {
           onError(new Error('Cannot process non-function on nexpect stack.'), true);
           return false;
         }
-        else if (['_expect', '_sendline', '_wait'].indexOf(currentFn.name) === -1) {
+        else if (['_expect', '_sendline', '_wait', '_sendEof'].indexOf(currentFn.name) === -1) {
           //
           // If the `currentFn` is a function, but not those set by `.sendline()` or
           // `.expect()` then short-circuit with an error.
@@ -147,9 +155,9 @@ function chain (context) {
             evalContext(data, '_expect');
           }
         }
-        else if (currentFn.name === '_sendline') {
+        else {
           //
-          // If the `currentFn` is a `_sendline` function then evaluate
+          // If the `currentFn` is any other function then evaluate
           // it and return.
           //
           currentFn();


### PR DESCRIPTION
1. Improve the error reported when the child process exits before the
   whole queue is processed.
2. Add a command to close child's stdin stream.
