### PR TITLE
Fix handling of consecutive _send* calls

### DIFF
--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -19,6 +19,7 @@ function chain (context) {
       _expect.shift = true;
       _expect.expectation = expectation;
       _expect.description = '[expect] ' + expectation;
+      _expect.requiresInput = true;
       context.queue.push(_expect);
 
       return chain(context);
@@ -31,6 +32,7 @@ function chain (context) {
       _wait.shift = false;
       _wait.expectation = expectation;
       _wait.description = '[wait] ' + expectation;
+      _wait.requiresInput = true;
       context.queue.push(_wait);
       return chain(context);
     },
@@ -45,6 +47,7 @@ function chain (context) {
 
       _sendline.shift = true;
       _sendline.description = '[sendline] ' + line;
+      _sendline.requiresInput = false;
       context.queue.push(_sendline);
       return chain(context);
     },
@@ -53,6 +56,8 @@ function chain (context) {
         context.process.stdin.destroy();
       };
       _sendEof.shift = true;
+      _sendEof.description = '[sendEof]';
+      _sendEof.requiresInput = false;
       context.queue.push(_sendEof);
       return chain(context);
     },
@@ -157,10 +162,14 @@ function chain (context) {
         }
         else {
           //
-          // If the `currentFn` is any other function then evaluate
-          // it and return.
+          // If the `currentFn` is any other function then evaluate it
           //
           currentFn();
+
+          // Evaluate the next function if it does not need input
+          var nextFn = context.queue[0];
+          if (nextFn && !nextFn.requiresInput)
+            evalContext(data);
         }
       }
 


### PR DESCRIPTION
Previously, two consecutive calls of _send\* functions will execute
the first one only. This commit fixes this problem.

Example reproducing the bug:

```
spawn(...)
  .expect('prompt')
  .sendLine('response')
  .sendEof()
  .run(...);
```

/to: @sam-github please review
