### PR TITLE
Fixed bug where nexpect hangs if first command in script is sendline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,52 @@
 node_modules
 npm-debug.log
 .DS_Store
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -301,7 +301,11 @@ function chain (context) {
           return;
         }
 
-        callback(null, stdout, signal || code);
+          callback(null, stdout, signal || code);
+      });
+
+      setTimeout(function() {
+        evalContext();
       });
 
       return context.process;

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -301,7 +301,7 @@ function chain (context) {
           return;
         }
 
-          callback(null, stdout, signal || code);
+        callback(null, stdout, signal || code);
       });
 
       setTimeout(function() {


### PR DESCRIPTION
It seems everything is driven from the on("data") event, so if your script must first send something, it just hangs