### PR TITLE
Allow passing a function to expect() and wait()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ and then returns a new chain with the specified `command`, `params`, and `option
 
 ### function expect (expectation)
 
-* expectation {string|RegExp} Output to assert on the target stream
+* expectation {string|RegExp|function} Output to assert on the target stream
 
 Expect that the next line of output matches the expectation.
 Throw an error if it does not.
@@ -57,7 +57,7 @@ a substring) or a RegExp (the line should match the expression).
 
 ### function wait (expectation, callback)
 
-* expectation {string|RegExp} Output to assert on the target stream
+* expectation {string|RegExp|function} Output to assert on the target stream
 * callback {Function} **Optional** Callback to be called when output matches stream
 
 Wait for a line of output that matches the expectation, discarding lines

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -312,6 +312,8 @@ function chain (context) {
 function testExpectation(data, expectation) {
   if (util.isRegExp(expectation)) {
     return expectation.test(data);
+  } else if (typeof expectation === 'function') {
+    return Boolean(expectation(data));
   } else {
     return data.indexOf(expectation) > -1;
   }

--- a/test/nexpect-test.js
+++ b/test/nexpect-test.js
@@ -66,6 +66,10 @@ vows.describe('nexpect').addBatch({
           nexpect.spawn("echo", ["hello"])
                  .expect(/^hello$/)
         ),
+        "when a function expectation is met": assertSpawn(
+          nexpect.spawn("echo", ["hello"])
+                 .expect(function (output) {return output === "hello";})
+        ),
       },
       "and using the wait() method": {
         "when assertions are met": assertSpawn(

--- a/test/nexpect-test.js
+++ b/test/nexpect-test.js
@@ -81,6 +81,15 @@ vows.describe('nexpect').addBatch({
                  .sendline('second-prompt')
                  .expect('second-prompt')
         ),
+        "when asserting with RegExps or functions": assertSpawn(
+          nexpect.spawn(path.join(__dirname, 'fixtures', 'prompt-and-respond'))
+                 .wait(/first/)
+                 .sendline('first-prompt')
+                 .expect('first-prompt')
+                 .wait(function (output) {return /second/.test(output);})
+                 .sendline('second-prompt')
+                 .expect('second-prompt')
+        ),
         "when the last assertion is never met": assertError(
           nexpect.spawn(path.join(__dirname, 'fixtures', 'prompt-and-respond'))
                  .wait('first')


### PR DESCRIPTION
My use case: I’m analyzing JSON output. It’s impossible to do it reliably with string or RegExp matching.