### PR TITLE
Provide stream output on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ which causes the app to block on input when the input stream is a pipe.
 Runs the `context` against the specified `context.command` and
 `context.params`.
 
+In case of error, output received on the designated stream will be available
+as an array of lines as `err.stdout`.
 
 ## Example
 

--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -152,7 +152,7 @@ function chain (context) {
           //
           return currentFn(data) === true ?
             evalContext(data, '_expect') :
-            onError(createExpectationError(currentFn.expectation, data), true);
+            onError(createExpectationError(currentFn.expectation, data, stdout), true);
         }
         else if (currentFn.name === '_wait') {
           //
@@ -219,12 +219,12 @@ function chain (context) {
 
         if (!lastLine) {
           onError(createUnexpectedEndError(
-            'No data from child with non-empty queue.', remainingQueue));
+            'No data from child with non-empty queue.', remainingQueue, stdout));
           return false;
         }
         else if (context.queue.length > 0) {
           onError(createUnexpectedEndError(
-            'Non-empty queue on spawn exit.', remainingQueue));
+            'Non-empty queue on spawn exit.', remainingQueue, stdout));
           return false;
         }
         else if (!validateFnType(currentFn)) {
@@ -237,7 +237,7 @@ function chain (context) {
         }
         else if (currentFn.name === '_wait' || currentFn.name === '_expect') {
           if (currentFn(lastLine) !== true) {
-            onError(createExpectationError(currentFn.expectation, lastLine));
+            onError(createExpectationError(currentFn.expectation, lastLine, stdout));
             return false;
           }
         }
@@ -317,17 +317,19 @@ function testExpectation(data, expectation) {
   }
 }
 
-function createUnexpectedEndError(message, remainingQueue) {
+function createUnexpectedEndError(message, remainingQueue, stdout) {
   var desc = remainingQueue.map(function(it) { return it.description; });
   var msg = message + '\n' + desc.join('\n');
-  return new AssertionError({
+  var err = new AssertionError({
     message: msg,
     expected: [],
     actual: desc
   });
+  err.stdout = stdout;
+  return err;
 }
 
-function createExpectationError(expected, actual) {
+function createExpectationError(expected, actual, stdout) {
   var expectation;
   if (util.isRegExp(expected))
     expectation = 'to match ' + expected;
@@ -339,6 +341,7 @@ function createExpectationError(expected, actual) {
     actual: actual,
     expected: expected
   });
+  err.stdout = stdout;
   return err;
 }
 


### PR DESCRIPTION
Resolves issue#30.  Stdout (actually, the captured stream ouput, could be stdout, stderr or both) is provided, as a line array, as a property of the error object.
