### PR TITLE
Improve Windows compatibility

### DIFF
--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -257,7 +257,8 @@ function chain (context) {
 
       options = {
         cwd: context.cwd,
-        env: context.env
+        env: context.env,
+        shell: context.shell
       };
 
       //


### PR DESCRIPTION
Sometimes the [`shell`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) option is [needed](https://github.com/nodejs/node-v0.x-archive/issues/2318#issuecomment-263852511) for Windows compatibility. This PR exposes that option of `child_process.spawn()`.