### PR TITLE
fix: update pathname parsing (#38)

### DIFF
--- a/lib/nexpect.js
+++ b/lib/nexpect.js
@@ -6,6 +6,7 @@
  */
 var spawn = require('cross-spawn');
 var util = require('util');
+var path = require('path');
 var AssertionError = require('assert').AssertionError;
 
 function chain (context) {
@@ -357,9 +358,9 @@ function nspawn (command, params, options) {
     command = params.shift();
   }
   else if (typeof command === 'string') {
-    command = command.split(' ');
-    params  = params || command.slice(1);
-    command = command[0];
+    var parsedPath = path.parse(command);
+    command = path.join(parsedPath.dir, parsedPath.base.split(' ')[0]);
+    params = params || parsedPath.base.split(' ').splice(1);
   }
 
   options = options || {};


### PR DESCRIPTION
# Description:
The pull request fixes a parsing issue in `nspawn` function, where the pathname containing spaces in them.

Fixes #38 
